### PR TITLE
fix: 修复 Docker 部署时 prisma 命令找不到的问题

### DIFF
--- a/apps/web/scripts/update-db.ts
+++ b/apps/web/scripts/update-db.ts
@@ -214,25 +214,17 @@ async function runMigrateDeploy(): Promise<void> {
   try {
     rlog.info("> Running prisma migrate deploy...");
 
-    // 确保 .prisma/client 存在
-    const clientPath = path.join(
-      process.cwd(),
-      "node_modules",
-      ".prisma",
-      "client",
+    const { runPrismaMigrateDeploy } = await import(
+      "@/lib/server/prisma-migrate"
     );
-    if (!fs.existsSync(clientPath)) {
-      rlog.info("  Generating Prisma client first...");
-      execSync("npx prisma generate", {
-        stdio: "pipe",
-        cwd: process.cwd(),
-      });
-    }
 
-    const output = execSync("npx prisma migrate deploy", {
-      stdio: "pipe",
+    let output = "";
+    await runPrismaMigrateDeploy({
       cwd: process.cwd(),
-      encoding: "utf-8",
+      logger: (line: string) => {
+        output += line + "\n";
+        rlog.info(line);
+      },
     });
 
     // 如果输出包含有用信息，显示它

--- a/apps/web/src/lib/server/prisma-migrate.ts
+++ b/apps/web/src/lib/server/prisma-migrate.ts
@@ -103,6 +103,23 @@ function splitLines(value: string): string[] {
     .filter((line) => line.length > 0);
 }
 
+function runPrismaGenerate(
+  cliPath: string,
+  schemaPath: string,
+  cwd: string,
+): void {
+  const genArgs = [cliPath, "generate", "--schema", schemaPath];
+  execFileSync(process.execPath, genArgs, {
+    cwd,
+    env: {
+      ...process.env,
+      PRISMA_HIDE_UPDATE_MESSAGE: "1",
+    },
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+}
+
 export async function runPrismaMigrateDeploy(options?: {
   cwd?: string;
   logger?: Logger;
@@ -112,6 +129,13 @@ export async function runPrismaMigrateDeploy(options?: {
   const cliPath = resolvePrismaCliPath(cwd);
   const schemaPath = resolvePrismaSchemaPath(cwd);
   const configPath = resolvePrismaConfigPath(cwd);
+
+  // 先执行 prisma generate，确保 Prisma Client 已生成
+  const clientPath = path.join(cwd, "node_modules", ".prisma", "client");
+  if (!fs.existsSync(clientPath)) {
+    runPrismaGenerate(cliPath, schemaPath, cwd);
+  }
+
   const cliArgs = [cliPath, "migrate", "deploy", "--schema", schemaPath];
 
   if (configPath) {


### PR DESCRIPTION
### 问题\nDocker 部署时运行时初始化报错：sh: 1: prisma: not found\n\n### 原因\nupdate-db.ts 中使用 npx prisma 调用，但 Docker 运行镜像中 Prisma CLI 安装在 /app/prisma-runtime/ 目录，不在 PATH 中。\n\n### 修复\n1. prisma-migrate.ts：runPrismaMigrateDeploy 增加前置 prisma generate 步骤\n2. update-db.ts：复用 runPrismaMigrateDeploy 而非直接 npx 调用